### PR TITLE
feat: start tracking version info in the saved file

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ pytest
 ruff
 pytest-cov
 psutil
+pytest-mock

--- a/src/textsearchpy/index.py
+++ b/src/textsearchpy/index.py
@@ -7,6 +7,7 @@ import uuid
 import os
 import math
 from queue import PriorityQueue
+import importlib.metadata
 
 from .tokenizers import SimpleTokenizer, Tokenizer
 from .normalizers import TokenNormalizer, LowerCaseNormalizer
@@ -212,6 +213,9 @@ class Index:
         document_file_path = os.path.join(path, "docs.jsonl")
         index_file_path = os.path.join(path, "index.json")
 
+        # fetch the version of the package
+        version_string = importlib.metadata.version("textsearchpy")
+
         if os.path.exists(document_file_path):
             raise TextSearchPyError(f"{document_file_path} already exists")
         if os.path.exists(index_file_path):
@@ -224,6 +228,7 @@ class Index:
 
         with open(index_file_path, "w") as index_file:
             file_body = {
+                "version": version_string,
                 "token_normalizers": [
                     t.__class__.__name__ for t in self.token_normalizers
                 ],

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -382,13 +382,17 @@ def test_query_with_filtered_tokens():
     assert len(docs) == 1
 
 
-def test_index_save_load(tmp_path):
+def test_index_save_load(tmp_path, mocker):
     index = Index()
     doc1 = Document(text="you like cookie")
     doc2 = Document(text="we like cake")
     index.append([doc1, doc2])
 
     save_path = str(tmp_path / "test_save")
+
+    mock_version_number = "1.0.0"
+
+    mocker.patch("importlib.metadata.version", return_value=mock_version_number)
     index.save(path=save_path)
 
     index_file = os.path.join(save_path, "index.json")
@@ -403,6 +407,7 @@ def test_index_save_load(tmp_path):
     assert saved_index_file["tokenizer"] == "SimpleTokenizer"
     assert len(saved_index_file["inverted_index"]) == 5
     assert len(saved_index_file["positional_index"]) == 5
+    assert saved_index_file["version"] == mock_version_number
 
     saved_docs = []
     with open(doc_file, "r") as f:


### PR DESCRIPTION
Context:
- add in version number for textsearchpy package in the saved file, for future safety check and additional metadata tracking